### PR TITLE
Make float to bfloat16 conversion explicit

### DIFF
--- a/biovault_bfloat16.h
+++ b/biovault_bfloat16.h
@@ -33,6 +33,7 @@ namespace biovault {
 
 	public:
 		bfloat16_t() = default;
+
 		constexpr bfloat16_t(const std::uint16_t r, bool) : raw_bits_(r) {}
 
 		// Supports narrowing (lossy) conversion from 32-bit float to bfloat16.
@@ -65,7 +66,12 @@ namespace biovault {
 			}
 		}
 
-		operator float() const;
+		operator float() const {
+			const std::uint16_t iraw[2] = { 0, raw_bits_ };
+			float f;
+			std::memcpy(&f, iraw, sizeof(float));
+			return f;
+		}
 
 		bfloat16_t &operator+=(const bfloat16_t a) {
 			(*this) = bfloat16_t{ float{*this} + float{a} };
@@ -74,12 +80,5 @@ namespace biovault {
 	};
 
 	static_assert(sizeof(bfloat16_t) == 2, "bfloat16_t must be 2 bytes");
-
-	inline bfloat16_t::operator float() const {
-		const std::uint16_t iraw[2] = { 0, raw_bits_ };
-		float f;
-		std::memcpy(&f, iraw, sizeof(float));
-		return f;
-	}
 
 }

--- a/biovault_bfloat16.h
+++ b/biovault_bfloat16.h
@@ -35,7 +35,8 @@ namespace biovault {
 		bfloat16_t() = default;
 		constexpr bfloat16_t(const std::uint16_t r, bool) : raw_bits_(r) {}
 
-		bfloat16_t(const float f) {
+		// Supports narrowing (lossy) conversion from 32-bit float to bfloat16.
+		explicit bfloat16_t(const float f) {
 			std::uint16_t iraw[2];
 			std::memcpy(iraw, &f, sizeof(float));
 
@@ -67,7 +68,7 @@ namespace biovault {
 		operator float() const;
 
 		bfloat16_t &operator+=(const bfloat16_t a) {
-			(*this) = (float)(*this) + (float)a;
+			(*this) = bfloat16_t{ float{*this} + float{a} };
 			return *this;
 		}
 	};


### PR DESCRIPTION
Made the converting constructor `bfloat16_t(float)` explicit. Placed the implementation of the conversion operator float() within the class definition.